### PR TITLE
removed JMS event properties from ontology

### DIFF
--- a/repository.rdf
+++ b/repository.rdf
@@ -19,9 +19,9 @@
         <rdfs:label xml:lang="en">Fedora Commons Repository Ontology</rdfs:label>
         <rdfs:comment xml:lang="en">Ontology for the Fedora data model, intended primarily to make it possible to expose Fedora-curated RDF predicates via de-reference-able URIs.</rdfs:comment>
     </owl:Ontology>
-    
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Data properties
@@ -30,22 +30,13 @@
      -->
 
 
-    
-    <!-- http://fedora.info/definitions/v4/repository#baseURL -->
-
-    <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#baseURL">
-        <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
-        <rdfs:comment xml:lang="en">Property used by event system for the repository baseURL.</rdfs:comment>
-    </owl:DatatypeProperty>
-
-
 
     <!-- http://fedora.info/definitions/v4/repository#clusterCacheMode -->
 
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#clusterCacheMode">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#clusterMembers -->
@@ -53,7 +44,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#clusterMembers">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#clusterName -->
@@ -62,7 +53,7 @@
         <rdfs:range rdf:resource="&xsd;string"/>
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#clusterNodeAddress -->
@@ -70,7 +61,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#clusterNodeAddress">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#clusterNodeView -->
@@ -78,7 +69,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#clusterNodeView">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#clusterPhysicalAddress -->
@@ -86,7 +77,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#clusterPhysicalAddress">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#clusterSize -->
@@ -95,7 +86,7 @@
         <rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#computedChecksum -->
@@ -103,7 +94,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#computedChecksum">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#computedSize -->
@@ -111,7 +102,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#computedSize">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#couldNotStoreProperty -->
@@ -119,7 +110,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#couldNotStoreProperty">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#created -->
@@ -128,22 +119,13 @@
         <rdfs:range rdf:resource="&xsd;dateTime"/>
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#createdBy -->
 
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#createdBy">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
-    </owl:DatatypeProperty>
-    
-
-
-    <!-- http://fedora.info/definitions/v4/repository#eventType -->
-
-    <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#eventType">
-        <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
-        <rdfs:comment xml:lang="en">Property used by event system for the event type.</rdfs:comment>
     </owl:DatatypeProperty>
 
 
@@ -153,7 +135,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#frozenMixinTypes">
         <rdfs:subPropertyOf rdf:resource="http://fedora.info/definitions/v4/repository#mixinTypes"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#frozenPrimaryType -->
@@ -161,7 +143,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#frozenPrimaryType">
         <rdfs:subPropertyOf rdf:resource="http://fedora.info/definitions/v4/repository#primaryType"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#frozenUuid -->
@@ -178,7 +160,7 @@
         <rdfs:range rdf:resource="&xsd;anyURI"/>
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#hasLockToken -->
@@ -193,7 +175,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#hasNodeType">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#hasVersionLabel -->
@@ -201,15 +183,6 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#hasVersionLabel">
         <rdfs:range rdf:resource="&xsd;string"/>
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
-    </owl:DatatypeProperty>
-    
-
-
-    <!-- http://fedora.info/definitions/v4/repository#identifier -->
-
-    <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#identifier">
-        <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
-        <rdfs:comment xml:lang="en">Property used by event system for repository identifiers.</rdfs:comment>
     </owl:DatatypeProperty>
 
 
@@ -224,7 +197,7 @@
 
 
     <!-- http://fedora.info/definitions/v4/repository#isDeep -->
-    
+
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#isDeep">
         <rdfs:domain rdf:resource="http://fedora.info/definitions/v4/repository#Lock"/>
         <rdfs:range rdf:resource="&xsd;boolean"/>
@@ -239,7 +212,7 @@
         <rdfs:range rdf:resource="&xsd;dateTime"/>
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#lastModifiedBy -->
@@ -247,7 +220,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#lastModifiedBy">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#mimeType -->
@@ -256,7 +229,7 @@
         <rdfs:range rdf:resource="&xsd;string"/>
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#mixinTypes -->
@@ -264,7 +237,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#mixinTypes">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#numFixityChecks -->
@@ -273,7 +246,7 @@
         <rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#numFixityErrors -->
@@ -282,7 +255,7 @@
         <rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#numFixityRepaired -->
@@ -291,7 +264,7 @@
         <rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#numberOfChildren -->
@@ -300,7 +273,7 @@
         <rdfs:range rdf:resource="&xsd;nonNegativeInteger"/>
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#objectCount -->
@@ -308,7 +281,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#objectCount">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#objectSize -->
@@ -316,7 +289,7 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#objectSize">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#primaryType -->
@@ -324,22 +297,15 @@
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#primaryType">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-  
-  
+
+
     <!-- http://fedora.info/definitions/v4/repository#UnmappedType -->
-     
+
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#UnmappedType">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
 
 
-    <!-- http://fedora.info/definitions/v4/repository#properties -->
-
-    <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#properties">
-        <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
-        <rdfs:comment xml:lang="en">Property used by event system for property names.</rdfs:comment>
-    </owl:DatatypeProperty>
 
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#repository.custom.rep.name">
         <rdf:subPropertyOf rdf:resource="&owl;topDataProperty"/>
@@ -491,24 +457,15 @@
 
 
 
-    <!-- http://fedora.info/definitions/v4/repository#timestamp -->
-
-    <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#timestamp">
-        <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
-        <rdfs:comment xml:lang="en">Property used by event system for event timestamps.</rdfs:comment>
-    </owl:DatatypeProperty>
-
-
-
     <!-- http://fedora.info/definitions/v4/repository#uuid -->
 
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#uuid">
         <rdfs:subPropertyOf rdf:resource="&owl;topDataProperty"/>
     </owl:DatatypeProperty>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Object Properties
@@ -516,7 +473,7 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#baseVersion -->
@@ -527,7 +484,7 @@
         <rdfs:domain rdf:resource="http://fedora.info/definitions/v4/repository#Container"/>
         <rdfs:range rdf:resource="http://fedora.info/definitions/v4/repository#Version"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#hasChild -->
@@ -545,7 +502,7 @@
             </owl:Class>
         </rdfs:range>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#hasContent -->
@@ -560,7 +517,7 @@
 
 
     <!-- http://fedora.info/definitions/v4/repository#hasDefaultWorkspace -->
-    
+
     <owl:ObjectProperty rdf:about="http://fedora.info/definitions/v4/repository#hasDefaultWorkspace">
         <rdfs:label xml:lang="en">has default workspace</rdfs:label>
         <rdfs:comment xml:lang="en">Indicates the default workspace of the repository.</rdfs:comment>
@@ -596,7 +553,7 @@
         <rdfs:range rdf:resource="http://fedora.info/definitions/v4/repository#Container"/>
         <rdfs:domain rdf:resource="http://fedora.info/definitions/v4/repository#Resource"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#hasResultsMember -->
@@ -605,7 +562,7 @@
         <rdfs:label xml:lang="en">has results member</rdfs:label>
         <rdfs:range rdf:resource="http://fedora.info/definitions/v4/repository#Resource"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#hasVersion -->
@@ -636,7 +593,7 @@
         <rdfs:domain rdf:resource="http://fedora.info/definitions/v4/repository#Binary"/>
         <rdfs:range rdf:resource="http://fedora.info/definitions/v4/repository#NonRdfSourceDescription"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#isFixityOf -->
@@ -647,7 +604,7 @@
         <rdfs:range rdf:resource="http://fedora.info/definitions/v4/repository#Binary"/>
         <rdfs:domain rdf:resource="http://fedora.info/definitions/v4/repository#Fixity"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#predecessors -->
@@ -657,10 +614,10 @@
         <rdfs:range rdf:resource="http://fedora.info/definitions/v4/repository#Version"/>
         <rdfs:domain rdf:resource="http://fedora.info/definitions/v4/repository#Version"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Classes
@@ -668,7 +625,7 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#AnnotatedResource -->
@@ -678,7 +635,7 @@
         <rdfs:subClassOf rdf:resource="http://fedora.info/definitions/v4/repository#Resource"/>
         <rdfs:comment xml:lang="en">A Resource that maintains properties in its own right.</rdfs:comment>
     </owl:Class>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#Binary -->
@@ -690,7 +647,7 @@
         <owl:disjointWith rdf:resource="http://fedora.info/definitions/v4/repository#Container"/>
         <rdfs:comment xml:lang="en">A bitstream, with no further data properties.</rdfs:comment>
     </owl:Class>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#Blanknode -->
@@ -721,7 +678,7 @@
         <owl:disjointWith rdf:resource="http://fedora.info/definitions/v4/repository#Container"/>
         <rdfs:comment xml:lang="en">A container for a bitstream and associated properties.</rdfs:comment>
     </owl:Class>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#DublinCoreDescribable -->
@@ -751,7 +708,7 @@
         <owl:disjointWith rdf:resource="http://fedora.info/definitions/v4/repository#Resource"/>
         <rdfs:comment xml:lang="en">A calculated or recorded result of a fixity measurement on a bitstream.</rdfs:comment>
     </owl:Class>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#InboundReferences -->
@@ -761,7 +718,7 @@
         <rdfs:subClassOf rdf:resource="http://fedora.info/definitions/v4/repository#Thing"/>
         <rdfs:comment xml:lang="en">The set of triples representing other repository resources which link to a given resource.</rdfs:comment>
     </owl:Class>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#nodeTypeConfiguration -->
@@ -781,7 +738,7 @@
         <rdfs:subClassOf rdf:resource="http://fedora.info/definitions/v4/repository#AnnotatedResource"/>
         <rdfs:comment xml:lang="en">A Fedora Container: the fundamental quantum of durable content in a Fedora repository.</rdfs:comment>
     </owl:Class>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#Pairtree -->
@@ -810,7 +767,7 @@
         <rdfs:subClassOf rdf:resource="http://fedora.info/definitions/v4/repository#Thing"/>
         <rdfs:comment xml:lang="en">An entity that has been committed to the repository for safekeeping. For example, Fedora objects and datastreams are resources. A Fixity is not, because the provenance of the instance is entirely internal to the repository.</rdfs:comment>
     </owl:Class>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#ServerManaged -->
@@ -829,7 +786,7 @@
         <rdfs:label xml:lang="en">Fedora thing</rdfs:label>
         <rdfs:comment xml:lang="en">Something that is contemplated in the Fedora repository model.</rdfs:comment>
     </owl:Class>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#Tombstone -->
@@ -838,7 +795,7 @@
         <rdfs:label xml:lang="en">tombstone</rdfs:label>
         <rdfs:comment xml:lang="en">An entity that is a marker for a deleted node.</rdfs:comment>
     </owl:Class>
-    
+
 
 
     <!-- http://fedora.info/definitions/v4/repository#Version -->
@@ -847,19 +804,19 @@
         <rdfs:label xml:lang="en">A snapshot of a Fedora object at a given point in time.</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://fedora.info/definitions/v4/repository#Container"/>
     </owl:Class>
-  
-  
-  
-  <!-- 
+
+
+
+  <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // REST API
     //
     ///////////////////////////////////////////////////////////////////////////////////////
   -->
-  
-  
-  
+
+
+
     <owl:ObjectProperty rdf:about="http://fedora.info/definitions/v4/repository#hasAccessRoles">
       <rdfs:label xml:lang="en">has access roles</rdfs:label>
     </owl:ObjectProperty>
@@ -878,7 +835,7 @@
     <owl:ObjectProperty rdf:about="http://fedora.info/definitions/v4/repository#sparql">
       <rdfs:label xml:lang="en">has sparql service</rdfs:label>
     </owl:ObjectProperty>
-    
+
     <owl:DatatypeProperty rdf:about="http://fedora.info/definitions/v4/repository#digest">
       <rdfs:label xml:lang="en">digest</rdfs:label>
     </owl:DatatypeProperty>
@@ -897,7 +854,7 @@
       <rdfs:label xml:lang="en">writable</rdfs:label>
       <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
     </owl:DatatypeProperty>
-  
+
    <owl:ObjectProperty rdf:about="http://fedora.info/definitions/v4/repository#status">
      <rdfs:label xml:lang="en">status</rdfs:label>
      <rdfs:comment xml:lang="en">Describes the status of a resource, such as active or deleted.</rdfs:comment>
@@ -918,7 +875,7 @@
      <rdfs:comment xml:lang="en">The resource has been marked for deletion.</rdfs:comment>
      <rdf:type rdf:resource="http://fedora.info/definitions/v4/repository#ResourceStatus"/>
    </owl:NamedIndividual>
-  
+
 </rdf:RDF>
 
 


### PR DESCRIPTION
Fixes: https://jira.duraspace.org/browse/FCREPO-1267

This removes the following properties: `identifier`, `baseURL`, `timestamp`, `properties`, `eventType`
