### PR TITLE
Add `inactive` state to Object Status Property list

### DIFF
--- a/objState.rdf
+++ b/objState.rdf
@@ -24,19 +24,25 @@
 
     <owl:ObjectProperty rdf:about="http://fedora.info/definitions/1/0/access/objState">
       <rdfs:label xml:lang="en">status</rdfs:label>
-      <rdfs:comment xml:lang="en">Describes the state of a resource, such as active or deleted.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Describes the state of a resource, such as active, inactive, or deleted.</rdfs:comment>
       <rdfs:domain rdf:resource="http://fedora.info/definitions/v4/repository#Resource"/>
       <rdfs:range rdf:resource="http://fedora.info/definitions/1/0/access/ResourceStatus"/>
     </owl:ObjectProperty>
 
     <owl:Class rdf:about="http://fedora.info/definitions/1/0/access/ResourceStatus">
       <rdfs:label xml:lang="en">resource state</rdfs:label>
-      <rdfs:comment xml:lang="en">Values of the state property. The out-of-the-box values are active and deleted -- but additional values can be created.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Values of the state property. The out-of-the-box values are active, inactive, and deleted -- but additional values can be created.</rdfs:comment>
     </owl:Class>
 
     <owl:NamedIndividual rdf:about="http://fedora.info/definitions/1/0/access/active">
       <rdfs:label xml:lang="en">active</rdfs:label>
       <rdfs:comment xml:lang="en">The resource is active.</rdfs:comment>
+      <rdf:type rdf:resource="http://fedora.info/definitions/1/0/access/ResourceStatus"/>
+    </owl:NamedIndividual>
+
+    <owl:NamedIndividual rdf:about="http://fedora.info/definitions/1/0/access/inactive">
+      <rdfs:label xml:lang="en">inactive</rdfs:label>
+      <rdfs:comment xml:lang="en">The resource is inactive.</rdfs:comment>
       <rdf:type rdf:resource="http://fedora.info/definitions/1/0/access/ResourceStatus"/>
     </owl:NamedIndividual>
 


### PR DESCRIPTION
After some discussion in the Hydra community -- https://groups.google.com/d/topic/hydra-tech/2P2CCrk4LaU/discussion -- we're thinking this new state might be used as an initial state in deposit workflows where mediation must occur to "publish" an object, or could also possibly be used to "withdraw" an object without deleting it or marking it for deletion. This also achieves parity with the three object states provided by Fedora 3.